### PR TITLE
Extend firebase message.

### DIFF
--- a/backend/src/Notifo.Domain/Channels/MobilePush/MobilePushChannel.cs
+++ b/backend/src/Notifo.Domain/Channels/MobilePush/MobilePushChannel.cs
@@ -175,20 +175,7 @@ namespace Notifo.Domain.Channels.MobilePush
         {
             try
             {
-                var message = new Message
-                {
-                    Token = token,
-                    Notification = new Notification
-                    {
-                        Title = notification.Formatting.Subject
-                    }
-                };
-
-                if (!string.IsNullOrWhiteSpace(notification.Formatting.Body))
-                {
-                    message.Notification.Body = notification.Formatting.Body;
-                }
-
+                var message = notification.ToFirebaseMessage(token);
                 await messaging.SendAsync(message, ct);
             }
             catch (FirebaseMessagingException ex) when (ex.MessagingErrorCode == MessagingErrorCode.Unregistered)

--- a/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
@@ -1,0 +1,86 @@
+﻿// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using FirebaseAdmin.Messaging;
+using Notifo.Domain.UserNotifications;
+
+namespace Notifo.Domain.Channels.MobilePush
+{
+    public static class UserNotificationExtensions
+    {
+        public static Message ToFirebaseMessage(this UserNotification notification, string token)
+        {
+            var message = new Message
+            {
+                Token = token
+            };
+
+            var commonData = new Dictionary<string, string>();
+            commonData.AddIfPresent(() => notification.TrackingUrl);
+            commonData.AddIfPresent(() => notification.ConfirmUrl);
+            commonData.AddIfPresent(() => notification.Formatting.ConfirmText);
+            commonData.AddIfPresent(() => notification.Formatting.ImageSmall);
+            commonData.AddIfPresent(() => notification.Formatting.ImageLarge);
+
+            message.Data = commonData;
+
+            var androidData = new Dictionary<string, string>();
+            androidData.AddIfPresent(() => notification.Formatting.Subject);
+            androidData.AddIfPresent(() => notification.Formatting.Body);
+
+            message.Android = new AndroidConfig
+            {
+                Data = androidData
+            };
+
+            var apsAlert = new ApsAlert
+            {
+                Title = notification.Formatting.Subject,
+                Body = notification.Formatting.Body ?? string.Empty
+            };
+
+            message.Apns = new ApnsConfig
+            {
+                Aps = new Aps
+                {
+                    Alert = apsAlert,
+                    MutableContent = true
+                }
+            };
+
+            return message;
+        }
+
+        private static void AddIfPresent(this IDictionary<string, string> dictionary, Expression<Func<string?>> expression)
+        {
+            var value = expression.Compile().Invoke();
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return;
+            }
+
+            var propertyInfo = ((MemberExpression)expression.Body).Member as PropertyInfo;
+            if (propertyInfo == null)
+            {
+                return;
+            }
+
+            string name = propertyInfo.Name;
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return;
+            }
+
+            string key = $"{char.ToLowerInvariant(name[0])}{name[1..]}";
+            dictionary[key] = value;
+        }
+    }
+}

--- a/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
@@ -69,7 +69,7 @@ namespace Notifo.Domain.Channels.MobilePush
                 return;
             }
 
-            string key = $"{char.ToLowerInvariant(propertyName[0])}{propertyName[1..]}";
+            var key = $"{char.ToLowerInvariant(propertyName[0])}{propertyName[1..]}";
             dictionary[key] = propertyValue;
         }
     }

--- a/backend/tests/Notifo.Domain.Tests/Channels/MobilePush/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Channels/MobilePush/UserNotificationExtensionsTests.cs
@@ -1,0 +1,97 @@
+﻿// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Collections.Generic;
+using FluentAssertions;
+using Notifo.Domain.UserNotifications;
+using Xunit;
+
+namespace Notifo.Domain.Channels.MobilePush
+{
+    public class UserNotificationExtensionsTests
+    {
+        [Fact]
+        public void Should_generate_firebase_message()
+        {
+            string token = "token1";
+            string body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
+            string subject = "subject1";
+            string confirmText = "Got It!";
+            string imageSmall = "https://via.placeholder.com/100";
+            string imageLarge = "https://via.placeholder.com/600";
+            string trackingUrl = "https://track.notifo.com";
+            string confirmUrl = "https://confirm.notifo.com";
+
+            var notification = new UserNotification
+            {
+                Formatting = new NotificationFormatting<string>
+                {
+                    Body = body,
+                    Subject = subject,
+                    ImageSmall = imageSmall,
+                    ImageLarge = imageLarge,
+                    ConfirmText = confirmText,
+                    ConfirmMode = ConfirmMode.Explicit
+                },
+                TrackingUrl = trackingUrl,
+                ConfirmUrl = confirmUrl
+            };
+
+            var message = notification.ToFirebaseMessage(token);
+
+            message.Token.Should().BeEquivalentTo(token);
+            message.Data[nameof(confirmText)].Should().BeEquivalentTo(confirmText);
+            message.Data[nameof(imageSmall)].Should().BeEquivalentTo(imageSmall);
+            message.Data[nameof(imageLarge)].Should().BeEquivalentTo(imageLarge);
+            message.Data[nameof(trackingUrl)].Should().BeEquivalentTo(trackingUrl);
+            message.Data[nameof(confirmUrl)].Should().BeEquivalentTo(confirmUrl);
+
+            message.Android.Data[nameof(subject)].Should().BeEquivalentTo(subject);
+            message.Android.Data[nameof(body)].Should().BeEquivalentTo(body);
+
+            message.Apns.Aps.MutableContent.Should().BeTrue();
+            message.Apns.Aps.Alert.Title.Should().BeEquivalentTo(subject);
+            message.Apns.Aps.Alert.Body.Should().BeEquivalentTo(body);
+        }
+
+        [Fact]
+        public void Should_not_include_empty_fields_in_firebase_message()
+        {
+            string token = "token1";
+            string body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
+            string subject = "subject1";
+            string confirmText = "Got It!";
+            string? imageSmall = null;
+            string imageLarge = string.Empty;
+            string? trackingUrl = null;
+            string confirmUrl = "https://confirm.notifo.com";
+
+            var notification = new UserNotification
+            {
+                Formatting = new NotificationFormatting<string>
+                {
+                    Body = body,
+                    Subject = subject,
+                    ImageSmall = imageSmall,
+                    ImageLarge = imageLarge,
+                    ConfirmText = confirmText,
+                },
+                TrackingUrl = trackingUrl,
+                ConfirmUrl = confirmUrl
+            };
+
+            var message = notification.ToFirebaseMessage(token);
+
+            var data = (Dictionary<string, string>)message.Data;
+            data[nameof(confirmText)].Should().BeEquivalentTo(confirmText);
+            data[nameof(confirmUrl)].Should().BeEquivalentTo(confirmUrl);
+            data.Should().NotContainKey(nameof(imageLarge));
+            data.Should().NotContainKey(nameof(imageSmall));
+            data.Should().NotContainKey(nameof(trackingUrl));
+        }
+    }
+}

--- a/backend/tests/Notifo.Domain.Tests/Channels/MobilePush/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Channels/MobilePush/UserNotificationExtensionsTests.cs
@@ -17,14 +17,14 @@ namespace Notifo.Domain.Channels.MobilePush
         [Fact]
         public void Should_generate_firebase_message()
         {
-            string token = "token1";
-            string body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
-            string subject = "subject1";
-            string confirmText = "Got It!";
-            string imageSmall = "https://via.placeholder.com/100";
-            string imageLarge = "https://via.placeholder.com/600";
-            string trackingUrl = "https://track.notifo.com";
-            string confirmUrl = "https://confirm.notifo.com";
+            var token = "token1";
+            var body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
+            var subject = "subject1";
+            var confirmText = "Got It!";
+            var imageSmall = "https://via.placeholder.com/100";
+            var imageLarge = "https://via.placeholder.com/600";
+            var trackingUrl = "https://track.notifo.com";
+            var confirmUrl = "https://confirm.notifo.com";
 
             var notification = new UserNotification
             {
@@ -43,32 +43,32 @@ namespace Notifo.Domain.Channels.MobilePush
 
             var message = notification.ToFirebaseMessage(token);
 
-            message.Token.Should().BeEquivalentTo(token);
-            message.Data[nameof(confirmText)].Should().BeEquivalentTo(confirmText);
-            message.Data[nameof(imageSmall)].Should().BeEquivalentTo(imageSmall);
-            message.Data[nameof(imageLarge)].Should().BeEquivalentTo(imageLarge);
-            message.Data[nameof(trackingUrl)].Should().BeEquivalentTo(trackingUrl);
-            message.Data[nameof(confirmUrl)].Should().BeEquivalentTo(confirmUrl);
+            Assert.Equal(message.Token, token);
+            Assert.Equal(message.Data[nameof(confirmText)], confirmText);
+            Assert.Equal(message.Data[nameof(imageSmall)], imageSmall);
+            Assert.Equal(message.Data[nameof(imageLarge)], imageLarge);
+            Assert.Equal(message.Data[nameof(trackingUrl)], trackingUrl);
+            Assert.Equal(message.Data[nameof(confirmUrl)], confirmUrl);
 
-            message.Android.Data[nameof(subject)].Should().BeEquivalentTo(subject);
-            message.Android.Data[nameof(body)].Should().BeEquivalentTo(body);
+            Assert.Equal(message.Android.Data[nameof(subject)], subject);
+            Assert.Equal(message.Android.Data[nameof(body)], body);
 
-            message.Apns.Aps.MutableContent.Should().BeTrue();
-            message.Apns.Aps.Alert.Title.Should().BeEquivalentTo(subject);
-            message.Apns.Aps.Alert.Body.Should().BeEquivalentTo(body);
+            Assert.Equal(message.Apns.Aps.Alert.Title, subject);
+            Assert.Equal(message.Apns.Aps.Alert.Body, body);
+            Assert.True(message.Apns.Aps.MutableContent);
         }
 
         [Fact]
         public void Should_not_include_empty_fields_in_firebase_message()
         {
-            string token = "token1";
-            string body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
-            string subject = "subject1";
-            string confirmText = "Got It!";
+            var token = "token1";
+            var body = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr";
+            var subject = "subject1";
+            var confirmText = "Got It!";
             string? imageSmall = null;
-            string imageLarge = string.Empty;
+            var imageLarge = string.Empty;
             string? trackingUrl = null;
-            string confirmUrl = "https://confirm.notifo.com";
+            var confirmUrl = "https://confirm.notifo.com";
 
             var notification = new UserNotification
             {
@@ -86,12 +86,11 @@ namespace Notifo.Domain.Channels.MobilePush
 
             var message = notification.ToFirebaseMessage(token);
 
-            var data = (Dictionary<string, string>)message.Data;
-            data[nameof(confirmText)].Should().BeEquivalentTo(confirmText);
-            data[nameof(confirmUrl)].Should().BeEquivalentTo(confirmUrl);
-            data.Should().NotContainKey(nameof(imageLarge));
-            data.Should().NotContainKey(nameof(imageSmall));
-            data.Should().NotContainKey(nameof(trackingUrl));
+            Assert.Equal(message.Data[nameof(confirmText)], confirmText);
+            Assert.Equal(message.Data[nameof(confirmUrl)], confirmUrl);
+            Assert.False(message.Data.ContainsKey(nameof(imageLarge)));
+            Assert.False(message.Data.ContainsKey(nameof(imageSmall)));
+            Assert.False(message.Data.ContainsKey(nameof(trackingUrl)));
         }
     }
 }


### PR DESCRIPTION
This pull request extends a firebase message to include 
* Tracking URL
* Confirmation URL 
* Confirmation text
* Large image
* Small image

if they are present in user notification. 

It also uses [platform-specific fields](https://firebase.google.com/docs/cloud-messaging/concept-options#customizing-a-message-across-platforms) to enable offline message handling as described [here](https://github.com/notifo-io/sdk-xamarin/blob/master/docs/offline-device-handling.md).