### PR TITLE
iOS allow coalescing of the same notification.

### DIFF
--- a/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain/Channels/MobilePush/UserNotificationExtensions.cs
@@ -74,6 +74,10 @@ namespace Notifo.Domain.Channels.MobilePush
 
             message.Apns = new ApnsConfig
             {
+                Headers = new Dictionary<string, string>
+                {
+                    ["apns-collapse-id"] = notification.Id.ToString()
+                },
                 Aps = new Aps
                 {
                     Alert = apsAlert,


### PR DESCRIPTION
This PR adds `apns-collapse-id` to the iOS firebase message in order to be able to remove confirmation action buttons on iOS notifications when confirmed by other channels or devices.