### PR TITLE
Use Firebase data message as the wake-up notification.

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
@@ -24,17 +24,9 @@ namespace Notifo.Domain.Integrations.Firebase
 
             if (wakeup)
             {
-                message.Apns = new ApnsConfig
-                {
-                    Aps = new Aps
-                    {
-                        ContentAvailable = true
-                    },
-                    Headers = new Dictionary<string, string>
-                    {
-                        ["apns-priority"] = "5"
-                    }
-                };
+                message.Data =
+                    new Dictionary<string, string>()
+                        .WithNonEmpty("id", notification.Id.ToString());
 
                 return message;
             }

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
@@ -127,7 +127,8 @@ namespace Notifo.Domain.Integrations.Firebase
             var message = notification.ToFirebaseMessage(token, true);
 
             Assert.Equal(token, message.Token);
-            Assert.True(message.Apns.Aps.ContentAvailable);
-        }
+            Assert.Equal(message.Data[nameof(id)], id.ToString());
+            Assert.Null(message.Notification);
+          }
     }
 }


### PR DESCRIPTION
This PR fixes Firebase 'Invalid registration token' error while sending wake-up notification by using the Firebase [data message](https://firebase.google.com/docs/cloud-messaging/concept-options#data_messages) instead of [platform-specific](https://firebase.google.com/docs/cloud-messaging/concept-options#customizing-a-message-across-platforms) silent notification.