### PR TITLE
Use high priority for Android messages.

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
@@ -53,7 +53,8 @@ namespace Notifo.Domain.Integrations.Firebase
 
             message.Android = new AndroidConfig
             {
-                Data = androidData
+                Data = androidData,
+                Priority = Priority.High
             };
 
             var apsAlert = new ApsAlert


### PR DESCRIPTION
If a user leaves an Android device unplugged and stationary for a period of time, with the screen off, the device enters [Doze mode](https://developer.android.com/training/monitoring-device-state/doze-standby). To enable a user to see a notification in doze mode right away, we should use an FCM [high-priority message](https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message).