### PR TITLE
Add silent field to the firebase message.

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
@@ -43,6 +43,7 @@ namespace Notifo.Domain.Integrations.Firebase
                     .WithNonEmpty("imageSmall", formatting.ImageSmall)
                     .WithNonEmpty("linkText", formatting.LinkText)
                     .WithNonEmpty("linkUrl", formatting.LinkUrl)
+                    .WithNonEmpty("silent", notification.Silent.ToString())
                     .WithNonEmpty("trackingUrl", notification.ComputeTrackingUrl(Providers.MobilePush, token))
                     .WithNonEmpty("data", notification.Data);
 

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
@@ -25,8 +25,8 @@ namespace Notifo.Domain.Integrations.Firebase
             var imageSmall = "https://via.placeholder.com/100";
             var linkUrl = "https://app.notifo.io";
             var linkText = "Go to link";
-            var subject = "subject1";
             var silent = false.ToString();
+            var subject = "subject1";
             var token = "token1";
             var trackingUrl = "https://track.notifo.com";
             var data = "data1";

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
@@ -26,6 +26,7 @@ namespace Notifo.Domain.Integrations.Firebase
             var linkUrl = "https://app.notifo.io";
             var linkText = "Go to link";
             var subject = "subject1";
+            var silent = false.ToString();
             var token = "token1";
             var trackingUrl = "https://track.notifo.com";
             var data = "data1";
@@ -46,6 +47,7 @@ namespace Notifo.Domain.Integrations.Firebase
                     LinkUrl = linkUrl,
                     Subject = subject
                 },
+                Silent = false,
                 TrackingUrl = trackingUrl,
                 Data = data
             };
@@ -61,6 +63,7 @@ namespace Notifo.Domain.Integrations.Firebase
             Assert.Equal(message.Data[nameof(imageLarge)], imageLarge);
             Assert.Equal(message.Data[nameof(linkText)], linkText);
             Assert.Equal(message.Data[nameof(linkUrl)], linkUrl);
+            Assert.Equal(message.Data[nameof(silent)], silent);
             Assert.Equal(message.Data[nameof(trackingUrl)], $"{trackingUrl}?channel=mobilepush&deviceIdentifier=token1");
             Assert.Equal(message.Data[nameof(data)], data);
 


### PR DESCRIPTION
This PR adds a `silent` field to the firebase message to control what notifications are being displayed to users and selectively silence some of them.