### PR TITLE
Fix Firebase_SilentAndroidDescription typo.

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Resources/Texts.Designer.cs
+++ b/backend/src/Notifo.Domain.Integrations/Resources/Texts.Designer.cs
@@ -178,7 +178,7 @@ namespace Notifo.Domain.Integrations.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Send silent notifications to iOS.
+        ///   Looks up a localized string similar to Send silent notifications to Android.
         /// </summary>
         internal static string Firebase_SilentAndroidDescription {
             get {

--- a/backend/src/Notifo.Domain.Integrations/Resources/Texts.resx
+++ b/backend/src/Notifo.Domain.Integrations/Resources/Texts.resx
@@ -157,7 +157,7 @@
     <value>Project ID</value>
   </data>
   <data name="Firebase_SilentAndroidDescription" xml:space="preserve">
-    <value>Send silent notifications to iOS</value>
+    <value>Send silent notifications to Android</value>
   </data>
   <data name="Firebase_SilentAndroidLabel" xml:space="preserve">
     <value>Silent (Android)</value>


### PR DESCRIPTION
This PR fixes a typo in `Firebase_SilentAndroidDescription` text constant.