### PR TITLE
Add time to live support for firebase messages.

### DIFF
--- a/backend/src/Notifo.Domain/Events/Event.cs
+++ b/backend/src/Notifo.Domain/Events/Event.cs
@@ -38,5 +38,7 @@ namespace Notifo.Domain.Events
         public CounterMap? Counters { get; set; }
 
         public bool Silent { get; set; }
+
+        public int? TimeToLiveInSeconds { get; set; }
     }
 }

--- a/backend/src/Notifo.Domain/Events/EventMessage.cs
+++ b/backend/src/Notifo.Domain/Events/EventMessage.cs
@@ -40,6 +40,8 @@ namespace Notifo.Domain.Events
 
         public bool Test { get; set; }
 
+        public int? TimeToLiveInSeconds { get; set; }
+
         private sealed class Validator : AbstractValidator<EventMessage>
         {
             public Validator()

--- a/backend/src/Notifo.Domain/UserEvents/UserEventMessage.cs
+++ b/backend/src/Notifo.Domain/UserEvents/UserEventMessage.cs
@@ -29,6 +29,8 @@ namespace Notifo.Domain.UserEvents
 
         public bool Test { get; set; }
 
+        public int? TimeToLiveInSeconds { get; set; }
+
         public Instant Created { get; set; }
 
         public NotificationSettings? EventSettings { get; set; }

--- a/backend/src/Notifo.Domain/UserNotifications/BaseUserNotification.cs
+++ b/backend/src/Notifo.Domain/UserNotifications/BaseUserNotification.cs
@@ -34,6 +34,8 @@ namespace Notifo.Domain.UserNotifications
 
         public bool Test { get; set; }
 
+        public int? TimeToLiveInSeconds { get; set; }
+
         public NotificationFormatting<string> Formatting { get; set; }
 
         public string? ComputeTrackingUrl(string channel, string? deviceIdentifier)

--- a/backend/src/Notifo/Areas/Api/Controllers/Events/Dtos/EventDto.cs
+++ b/backend/src/Notifo/Areas/Api/Controllers/Events/Dtos/EventDto.cs
@@ -90,6 +90,11 @@ namespace Notifo.Areas.Api.Controllers.Events.Dtos
         [Required]
         public bool Silent { get; set; }
 
+        /// <summary>
+        /// The time to live in seconds.
+        /// </summary>
+        public int? TimeToLiveInSeconds { get; set; }
+
         public static EventDto FromDomainObject(Event @event, App app)
         {
             var result = SimpleMapper.Map(@event, new EventDto

--- a/backend/src/Notifo/Areas/Api/Controllers/Events/Dtos/PublishDto.cs
+++ b/backend/src/Notifo/Areas/Api/Controllers/Events/Dtos/PublishDto.cs
@@ -73,6 +73,11 @@ namespace Notifo.Areas.Api.Controllers.Events.Dtos
         /// </summary>
         public bool Test { get; set; }
 
+        /// <summary>
+        /// The time to live in seconds.
+        /// </summary>
+        public int? TimeToLiveInSeconds { get; set; }
+
         public EventMessage ToEvent(string appId, string? topic = null)
         {
             var result = SimpleMapper.Map(this, new EventMessage());

--- a/frontend/src/app/pages/publish/PublishDialog.tsx
+++ b/frontend/src/app/pages/publish/PublishDialog.tsx
@@ -105,6 +105,11 @@ export const PublishDialog = () => {
 
                             <hr />
 
+                            <Forms.Number name='timeToLiveInSeconds'
+                                label={texts.common.timeToLive} min={0} max={2419200} />
+
+                            <hr />
+
                             <NotificationsForm.Settings
                                 field='settings' disabled={publishing} />
 

--- a/frontend/src/app/texts/en.ts
+++ b/frontend/src/app/texts/en.ts
@@ -102,7 +102,7 @@ export const EN = {
         templateMode: 'Use template?',
         text: 'Text',
         timestamp: 'Timestamp',
-        timeToLive: "Time to live in seconds",
+        timeToLive: 'Time to live in seconds',
         timezone: 'Timezone',
         threemaId: 'Threema ID',
         topic: 'Topic',

--- a/frontend/src/app/texts/en.ts
+++ b/frontend/src/app/texts/en.ts
@@ -102,6 +102,7 @@ export const EN = {
         templateMode: 'Use template?',
         text: 'Text',
         timestamp: 'Timestamp',
+        timeToLive: "Time to live in seconds",
         timezone: 'Timezone',
         threemaId: 'Threema ID',
         topic: 'Topic',


### PR DESCRIPTION
This PR adds support for [time to live](https://firebase.google.com/docs/cloud-messaging/concept-options#ttl) property for Firebase messages.


![chrome_2021-06-15_16-02-09](https://user-images.githubusercontent.com/8818052/122057348-341d1400-cdf3-11eb-87d1-d56c7fcc2c3f.png)
