### PR TITLE
Add apns-push-type header.

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
@@ -71,7 +71,8 @@ namespace Notifo.Domain.Integrations.Firebase
 
             var apnsHeaders = new Dictionary<string, string>
             {
-                ["apns-collapse-id"] = notification.Id.ToString()
+                ["apns-collapse-id"] = notification.Id.ToString(),
+                ["apns-push-type"] = "alert"
             };
 
             if (notification.TimeToLiveInSeconds is int timeToLive)


### PR DESCRIPTION
This PR adds `apns-push-type` header to firebase message configuration, because Apple [require](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/) this header to be included for watchOS apps. 