### PR TITLE
return subsciptions for subtopics for users/:id/subtopic

### DIFF
--- a/backend/src/Notifo.Domain/UserEvents/Pipeline/UserEventPublisher.cs
+++ b/backend/src/Notifo.Domain/UserEvents/Pipeline/UserEventPublisher.cs
@@ -212,6 +212,7 @@ namespace Notifo.Domain.UserEvents.Pipeline
                 {
                     yield return subscription;
                 }
+
                 if (IsUserTopic(topic, out var userId)) 
                 {
                     yield return new Subscription

--- a/backend/src/Notifo.Domain/UserEvents/Pipeline/UserEventPublisher.cs
+++ b/backend/src/Notifo.Domain/UserEvents/Pipeline/UserEventPublisher.cs
@@ -206,21 +206,21 @@ namespace Notifo.Domain.UserEvents.Pipeline
                     };
                 }
             }
-            else if (IsUserTopic(topic, out var userId))
-            {
-                yield return new Subscription
-                {
-                    AppId = @event.AppId,
-                    TopicPrefix = $"users/{userId}",
-                    TopicSettings = null,
-                    UserId = userId
-                };
-            }
             else
             {
                 await foreach (var subscription in subscriptionStore.QueryAsync(@event.AppId, @event.Topic, @event.CreatorId, ct))
                 {
                     yield return subscription;
+                }
+                if (IsUserTopic(topic, out var userId)) 
+                {
+                    yield return new Subscription
+                    {
+                        AppId = @event.AppId,
+                        TopicPrefix = $"users/{userId}",
+                        TopicSettings = null,
+                        UserId = userId
+                    };
                 }
             }
         }

--- a/backend/tests/Notifo.Domain.Tests/UserEvents/Pipeline/UserEventPublisherTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/UserEvents/Pipeline/UserEventPublisherTests.cs
@@ -267,9 +267,6 @@ namespace Notifo.Domain.UserEvents.Pipeline
                 }
             });
 
-            A.CallTo(() => subscriptionStore.QueryAsync(A<string>._, A<TopicId>._, A<string>._, ct))
-                .MustNotHaveHappened();
-
             A.CallTo(() => logStore.LogAsync(A<string>._, A<string>._))
                 .MustNotHaveHappened();
         }


### PR DESCRIPTION
When publishing Events to /users/1234/subtopic the subsciptions of the users are not loaded, but a dummy subsciption is created. This causes notifo not publishing a notification to it. more see #65 

!! WARNING !!
But with this fix the https://app.notifo.io/api/docs/index.html?url=/api/openapi.json#operation/Users_PostAllowedTopic seems not to work and a user can subscribe to anothers user topics