### PR TITLE
Bugfix existing mobile tokens removal on adding new token.

### DIFF
--- a/backend/src/Notifo.Domain/Users/AddUserMobileToken.cs
+++ b/backend/src/Notifo.Domain/Users/AddUserMobileToken.cs
@@ -31,7 +31,7 @@ namespace Notifo.Domain.Users
         {
             Validate<Validator>.It(this);
 
-            var newMobilePushTokens = new List<MobilePushToken>();
+            var newMobilePushTokens = user.MobilePushTokens.ToList();
 
             newMobilePushTokens.RemoveAll(x => x.Token == Token.Token);
             newMobilePushTokens.Add(Token);

--- a/backend/tests/Notifo.Domain.Tests/Users/AddUserMobileTokenTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Users/AddUserMobileTokenTests.cs
@@ -1,0 +1,42 @@
+﻿// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using FakeItEasy;
+using Notifo.Domain.Channels.MobilePush;
+using Notifo.Infrastructure.Collections;
+using Xunit;
+
+namespace Notifo.Domain.Users
+{
+    public class AddUserMobileTokenTests
+    {
+        [Fact]
+        public async Task Should_not_remove_existing_tokens_when_new_token_added()
+        {
+            var sut = new AddUserMobileToken();
+
+            string token1 = "test token 1";
+            string token2 = "test token 2";
+            string token3 = "test token 3";
+
+            sut.Token = new MobilePushToken { Token = token1 };
+
+            var user = new User
+            {
+                MobilePushTokens = new List<string> { token2, token3 }
+                        .Select(t => new MobilePushToken { Token = t })
+                        .ToReadonlyList(),
+            };
+
+            var updatedUser = await sut.ExecuteAsync(user, A.Fake<IServiceProvider>(), CancellationToken.None);
+
+            Assert.Contains(updatedUser?.MobilePushTokens, t => t.Token == token1);
+            Assert.Contains(updatedUser?.MobilePushTokens, t => t.Token == token2);
+            Assert.Contains(updatedUser?.MobilePushTokens, t => t.Token == token3);
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes the bug when the existing mobile tokens were removed after add mobile token command was executed.