### PR TITLE
Max notifications per user.

### DIFF
--- a/backend/src/Notifo.Domain/Events/EventsOptions.cs
+++ b/backend/src/Notifo.Domain/Events/EventsOptions.cs
@@ -15,7 +15,10 @@ namespace Notifo.Domain.Events
 
         public IEnumerable<ConfigurationError> Validate()
         {
-            yield break;
+            if (RetentionTime <= TimeSpan.Zero)
+            {
+                yield return new ConfigurationError("Retention time must be greater than zero.", nameof(RetentionTime));
+            }
         }
     }
 }

--- a/backend/src/Notifo.Domain/Notifo.Domain.csproj
+++ b/backend/src/Notifo.Domain/Notifo.Domain.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="NodaTime" Version="3.0.9" />
     <PackageReference Include="RefactoringEssentials" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.1.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
     <PackageReference Include="WebPush" Version="1.0.12" />

--- a/backend/src/Notifo.Domain/UserNotifications/MongoDb/MongoDbUserNotificationRepository.cs
+++ b/backend/src/Notifo.Domain/UserNotifications/MongoDb/MongoDbUserNotificationRepository.cs
@@ -13,12 +13,14 @@ using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 using Notifo.Infrastructure;
 using Notifo.Infrastructure.MongoDb;
+using Squidex.Log;
 
 namespace Notifo.Domain.UserNotifications.MongoDb
 {
     public sealed class MongoDbUserNotificationRepository : MongoDbRepository<UserNotification>, IUserNotificationRepository
     {
-        private readonly TimeSpan retentionTime;
+        private readonly UserNotificationsOptions options;
+        private readonly ISemanticLog log;
 
         static MongoDbUserNotificationRepository()
         {
@@ -66,10 +68,12 @@ namespace Notifo.Domain.UserNotifications.MongoDb
             });
         }
 
-        public MongoDbUserNotificationRepository(IMongoDatabase database, IOptions<UserNotificationsOptions> options)
+        public MongoDbUserNotificationRepository(IMongoDatabase database, ISemanticLog log, IOptions<UserNotificationsOptions> options)
             : base(database)
         {
-            retentionTime = options.Value.RetentionTime;
+            this.options = options.Value;
+
+            this.log = log;
         }
 
         protected override string CollectionName()
@@ -93,10 +97,18 @@ namespace Notifo.Domain.UserNotifications.MongoDb
             await Collection.Indexes.CreateOneAsync(
                 new CreateIndexModel<UserNotification>(
                     IndexKeys
+                        .Ascending(x => x.AppId)
+                        .Ascending(x => x.UserId)
+                        .Ascending(x => x.Created)),
+                null, ct);
+
+            await Collection.Indexes.CreateOneAsync(
+                new CreateIndexModel<UserNotification>(
+                    IndexKeys
                         .Descending(x => x.Created),
                     new CreateIndexOptions
                     {
-                        ExpireAfter = retentionTime
+                        ExpireAfter = options.RetentionTime
                     }),
                 null, ct);
         }
@@ -126,36 +138,7 @@ namespace Notifo.Domain.UserNotifications.MongoDb
         {
             using (var activity = Telemetry.Activities.StartActivity("MongoDbUserNotificationRepository/QueryAsync"))
             {
-                var filters = new List<FilterDefinition<UserNotification>>
-                {
-                    Filter.Eq(x => x.AppId, appId),
-                    Filter.Eq(x => x.UserId, userId),
-                    Filter.Gte(x => x.Updated, query.After)
-                };
-
-                switch (query.Scope)
-                {
-                    case UserNotificationQueryScope.Deleted:
-                        filters.Add(Filter.Eq(x => x.IsDeleted, true));
-                        break;
-
-                    case UserNotificationQueryScope.NonDeleted:
-                        filters.Add(Filter.Eq(x => x.IsDeleted, false));
-                        break;
-
-                    case UserNotificationQueryScope.All:
-                        filters.Add(Filter.Ne(nameof(UserNotification.IsDeleted), 0));
-                        break;
-                }
-
-                if (!string.IsNullOrWhiteSpace(query.Query))
-                {
-                    var regex = new BsonRegularExpression(Regex.Escape(query.Query), "i");
-
-                    filters.Add(Filter.Regex(x => x.Formatting.Subject, regex));
-                }
-
-                var filter = Filter.And(filters);
+                var filter = BuildFilter(appId, userId, query);
 
                 var resultItems = await Collection.Find(filter).SortByDescending(x => x.Created).ToListAsync(query, ct);
                 var resultTotal = (long)resultItems.Count;
@@ -299,10 +282,43 @@ namespace Notifo.Domain.UserNotifications.MongoDb
                 try
                 {
                     await Collection.InsertOneAsync(notification, null, ct);
+
+                    await CleanupAsync(notification, ct);
                 }
                 catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
                 {
                     throw new UniqueConstraintException();
+                }
+            }
+        }
+
+        private async Task CleanupAsync(UserNotification notification, CancellationToken ct)
+        {
+            if (options.MaxItemsPerUser <= 0 || options.MaxItemsPerUser >= int.MaxValue)
+            {
+                return;
+            }
+
+            using (Telemetry.Activities.StartActivity("MongoDbUserNotificationRepository/CleanupAsync"))
+            {
+                try
+                {
+                    var filter = BuildFilter(notification);
+
+                    var oldNotifications = Collection.Find(filter).Skip(options.MaxItemsPerUser).SortBy(x => x.Created).Only(x => x.Id).ToAsyncEnumerable(ct);
+
+                    await foreach (var batch in oldNotifications.Chunk(5000, ct))
+                    {
+                        var ids = batch.Select(x => x["_id"].AsString!);
+
+                        await Collection.DeleteManyAsync(Filter.In("_id", ids), ct);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, w => w
+                        .WriteProperty("action", "CleanupNotifications")
+                        .WriteProperty("status", "Failed"));
                 }
             }
         }
@@ -356,6 +372,51 @@ namespace Notifo.Domain.UserNotifications.MongoDb
                         Update.Min($"Channels.{channel}.FirstSeen", timestamp)));
                 }
             }
+        }
+
+        private static FilterDefinition<UserNotification> BuildFilter(UserNotification notification)
+        {
+            var filters = new List<FilterDefinition<UserNotification>>
+            {
+                Filter.Eq(x => x.AppId, notification.AppId),
+                Filter.Eq(x => x.UserId, notification.UserId)
+            };
+
+            return Filter.And(filters);
+        }
+
+        private static FilterDefinition<UserNotification> BuildFilter(string appId, string userId, UserNotificationQuery query)
+        {
+            var filters = new List<FilterDefinition<UserNotification>>
+            {
+                Filter.Eq(x => x.AppId, appId),
+                Filter.Eq(x => x.UserId, userId),
+                Filter.Gte(x => x.Updated, query.After)
+            };
+
+            switch (query.Scope)
+            {
+                case UserNotificationQueryScope.Deleted:
+                    filters.Add(Filter.Eq(x => x.IsDeleted, true));
+                    break;
+
+                case UserNotificationQueryScope.NonDeleted:
+                    filters.Add(Filter.Eq(x => x.IsDeleted, false));
+                    break;
+
+                case UserNotificationQueryScope.All:
+                    filters.Add(Filter.Ne(nameof(UserNotification.IsDeleted), 0));
+                    break;
+            }
+
+            if (!string.IsNullOrWhiteSpace(query.Query))
+            {
+                var regex = new BsonRegularExpression(Regex.Escape(query.Query), "i");
+
+                filters.Add(Filter.Regex(x => x.Formatting.Subject, regex));
+            }
+
+            return Filter.And(filters);
         }
     }
 }

--- a/backend/src/Notifo.Domain/UserNotifications/UserNotificationsOptions.cs
+++ b/backend/src/Notifo.Domain/UserNotifications/UserNotificationsOptions.cs
@@ -13,9 +13,14 @@ namespace Notifo.Domain.UserNotifications
     {
         public TimeSpan RetentionTime { get; set; } = TimeSpan.FromDays(20);
 
+        public int MaxItemsPerUser { get; set; } = 5000;
+
         public IEnumerable<ConfigurationError> Validate()
         {
-            yield break;
+            if (RetentionTime <= TimeSpan.Zero)
+            {
+                yield return new ConfigurationError("Retention time must be greater than zero.", nameof(RetentionTime));
+            }
         }
     }
 }

--- a/backend/src/Notifo.Infrastructure/CollectionExtensions.cs
+++ b/backend/src/Notifo.Infrastructure/CollectionExtensions.cs
@@ -12,19 +12,6 @@ namespace Notifo.Infrastructure
 {
     public static class CollectionExtensions
     {
-        public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source,
-            CancellationToken ct = default)
-        {
-            var list = new List<T>();
-
-            await foreach (var element in source.WithCancellation(ct))
-            {
-                list.Add(element);
-            }
-
-            return list;
-        }
-
         public static async IAsyncEnumerable<List<T>> Chunk<T>(this IAsyncEnumerable<T> source, int size,
             [EnumeratorCancellation] CancellationToken ct = default)
         {

--- a/backend/src/Notifo/Areas/Account/Controllers/AuthorizationController.cs
+++ b/backend/src/Notifo/Areas/Account/Controllers/AuthorizationController.cs
@@ -130,7 +130,7 @@ namespace Notifo.Areas.Account.Controllers
             var scopes = request.GetScopes();
 
             principal.SetScopes(request.GetScopes());
-            principal.SetResources(await scopeManager.ListResourcesAsync(scopes, HttpContext.RequestAborted).ToListAsync());
+            principal.SetResources(await scopeManager.ListResourcesAsync(scopes, HttpContext.RequestAborted).ToListAsync(HttpContext.RequestAborted));
 
             foreach (var claim in principal.Claims)
             {

--- a/backend/tests/Notifo.Domain.Tests/UserNotifications/MongoDb/MongoDbUserNotificationRepositoryFixture.cs
+++ b/backend/tests/Notifo.Domain.Tests/UserNotifications/MongoDb/MongoDbUserNotificationRepositoryFixture.cs
@@ -5,9 +5,11 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using FakeItEasy;
 using Microsoft.Extensions.Options;
 using MongoDB.Driver;
 using Notifo.Infrastructure.MongoDb;
+using Squidex.Log;
 
 namespace Notifo.Domain.UserNotifications.MongoDb
 {
@@ -17,12 +19,21 @@ namespace Notifo.Domain.UserNotifications.MongoDb
 
         public MongoDbUserNotificationRepositoryFixture()
         {
+            ActivityContextSerializer.Register();
+            ActivitySpanIdSerializer.Register();
+            ActivityTraceIdSerializer.Register();
+
             InstantSerializer.Register();
 
             var mongoClient = new MongoClient("mongodb://localhost");
             var mongoDatabase = mongoClient.GetDatabase("Notifo_Testing");
 
-            Repository = new MongoDbUserNotificationRepository(mongoDatabase, Options.Create(new UserNotificationsOptions()));
+            var options = new UserNotificationsOptions
+            {
+                MaxItemsPerUser = 100
+            };
+
+            Repository = new MongoDbUserNotificationRepository(mongoDatabase, A.Fake<ISemanticLog>(), Options.Create(options));
             Repository.InitializeAsync(default).Wait();
         }
 


### PR DESCRIPTION
Defines a number of max notifications per user (default 5000) and deletes older entries when inserting a new notification.

Closes #84 