### PR TITLE
Fix confirm bug

### DIFF
--- a/backend/src/Notifo/Areas/Api/Controllers/NotificationFormattingDto.cs
+++ b/backend/src/Notifo/Areas/Api/Controllers/NotificationFormattingDto.cs
@@ -68,7 +68,12 @@ namespace Notifo.Areas.Api.Controllers
         public NotificationFormatting<LocalizedText> ToDomainObject()
         {
             var result = SimpleMapper.Map(this, new NotificationFormatting<LocalizedText>());
-
+            
+            // TODO: The ConfirmMode enum is not being mapped, and is always null on the reult. There's probably a
+            // better way to do this in the SimpleMapper for enums in general, but I lack the C# knowledge and project
+            // familiarity to implement this there efficiently, thus opting for a simpler approach to get confirms working.
+            result.ConfirmMode = this.ConfirmMode;
+            
             return result;
         }
     }


### PR DESCRIPTION
We noticed that confirms were not behaving as expected. After some troubleshooting we found that no matter what the confirmMode is set to when publishing events, it always ends up as `None` which then makes it impossible to confirm any notifications because the query to mongodb when confirming a notification requires that the notification have the `Explicit` confirm mode. 

We discovered that this is due to the SimpleMapper not mapping the ConfirmMode enum properly, so it's always null after mapping. I believe it would be better to do a more generic fix in the mapper to handle enum values, but we lack the C# experience and project familiarity to do that confidently. This is a simple fix that gets notification confirmations working.