### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Calculate Version
         env:
@@ -28,13 +28,13 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 1000))" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: BUILD
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           push: false
           load: true
@@ -55,7 +55,7 @@ jobs:
         run: docker save notifo-tmp | gzip > notifo-tmp.tar.gz
 
       - name: Save Image to Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-dev-image-${{ github.sha }}
@@ -76,13 +76,13 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 1000))" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-dev-image-${{ github.sha }}
@@ -142,7 +142,7 @@ jobs:
        
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v1
+        uses: jwalton/gh-docker-logs@v2.2.1
         with:
          images: 'notifo-tmp,squidex/resizer'
          tail: '100'
@@ -163,10 +163,10 @@ jobs:
           echo "BUILD_NUMBER=$(($BUILD_NUMBER + 1000))" >> $GITHUB_ENV
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -174,7 +174,7 @@ jobs:
 
       - name: Get Image From Cache
         if: github.event_name != 'pull_request'
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-dev-image-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: BUILD
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3.2.0
         with:
           push: false
           load: true
@@ -44,7 +44,7 @@ jobs:
         run: docker save notifo-tmp | gzip > notifo-tmp.tar.gz
 
       - name: Save Image to Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-release-image-${{ github.sha }}
@@ -59,13 +59,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-release-image-${{ github.sha }}
@@ -125,7 +125,7 @@ jobs:
        
       - name: Dump docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v1
+        uses: jwalton/gh-docker-logs@v2.2.1
         with:
          images: 'notifo-tmp,squidex/resizer'
          tail: '100'
@@ -140,10 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -156,7 +156,7 @@ jobs:
           split-by: "."
 
       - name: Get Image From Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-release-image-${{ github.sha }}
@@ -181,13 +181,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Inject slug/short variables
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v4.3.2
 
       - name: Get Image From Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3.0.11
         with:
           path: notifo-tmp.tar.gz
           key: notifo-release-image-${{ github.sha }}

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3.1.0
 
       - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3.0.2
         with:
           dotnet-version: 6.0.100
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v2.1.0](https://github.com/docker/login-action/releases/tag/v2.1.0)** on 2022-10-12T07:04:14Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.0.11](https://github.com/actions/cache/releases/tag/v3.0.11)** on 2022-10-13T11:18:20Z
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v3.0.2](https://github.com/actions/setup-dotnet/releases/tag/v3.0.2)** on 2022-10-13T14:54:29Z
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v4.3.2](https://github.com/rlespinasse/github-slug-action/releases/tag/v4.3.2)** on 2022-10-17T19:25:58Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v2.2.1](https://github.com/docker/setup-buildx-action/releases/tag/v2.2.1)** on 2022-10-18T09:17:35Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v2.1.0](https://github.com/docker/setup-qemu-action/releases/tag/v2.1.0)** on 2022-10-12T13:40:23Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v3.2.0](https://github.com/docker/build-push-action/releases/tag/v3.2.0)** on 2022-10-12T07:10:45Z
* **[jwalton/gh-docker-logs](https://github.com/jwalton/gh-docker-logs)** published a new release **[v2.2.1](https://github.com/jwalton/gh-docker-logs/releases/tag/v2.2.1)** on 2022-10-13T16:13:34Z
