### PR TITLE
Fix iOS Wakup Message

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Firebase/UserNotificationExtensions.cs
@@ -26,6 +26,19 @@ public static class UserNotificationExtensions
                 new Dictionary<string, string>()
                     .WithNonEmpty("id", source.NotificationId.ToString());
 
+            message.Apns = new ApnsConfig
+            {
+                Headers =  new Dictionary<string, string>
+                {
+                    ["apns-push-type"] = "background",
+                    ["apns-priority"] = "5"
+                },
+                Aps = new Aps
+                {
+                    ContentAvailable = true
+                }
+            };
+
             return message;
         }
 

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.Should_create_silent_notification_when_flag_is_true.verified.txt
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.Should_create_silent_notification_when_flag_is_true.verified.txt
@@ -2,5 +2,15 @@
   Token: token1,
   Data: {
     id: Guid_1
+  },
+  Apns: {
+    Headers: {
+      apns-priority: 5,
+      apns-push-type: background
+    },
+    Aps: {
+      ContentAvailable: true,
+      MutableContent: false
+    }
   }
 }

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Firebase/UserNotificationExtensionsTests.cs
@@ -82,7 +82,7 @@ public class UserNotificationExtensionsTests
         var source = new MobilePushMessage
         {
             DeviceToken = token,
-            DeviceType = MobileDeviceType.Android,
+            DeviceType = MobileDeviceType.iOS,
             NotificationId = id,
             Wakeup = true
         };


### PR DESCRIPTION
After reviewing the iOS wake up message it looks like there are mandatory properties. This could be a reason for not delivered background notifications.
See https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app
There must be the content-available property. I wasn't able to remove the MutableContent Property but I would assume that this is still ok.
There is also a recommendation for setting the header and priority.
