### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4.0.0
 
       - name: Set up dotnet
-        uses: actions/setup-dotnet@v3.0.2
+        uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: 8.0.x
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-dotnet](https://github.com/actions/setup-dotnet)** published a new release **[v4.0.0](https://github.com/actions/setup-dotnet/releases/tag/v4.0.0)** on 2023-12-04T14:24:07Z
