### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: tools/TestSuite
 
       - name: Test - RUN
-        uses: kohlerdominik/docker-run-action@v1.1.0
+        uses: kohlerdominik/docker-run-action@v2.0.0
         with:
           image: mcr.microsoft.com/dotnet/sdk:8.0
           environment: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Test - RUN on GooglePubSub
         if: github.event_name != 'pull_request'
-        uses: kohlerdominik/docker-run-action@v1.1.0
+        uses: kohlerdominik/docker-run-action@v2.0.0
         with:
           image: mcr.microsoft.com/dotnet/sdk:8.0
           environment: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         working-directory: tools/TestSuite
 
       - name: Test - RUN
-        uses: kohlerdominik/docker-run-action@v1.1.0
+        uses: kohlerdominik/docker-run-action@v2.0.0
         with:
           image: mcr.microsoft.com/dotnet/sdk:8.0
           environment: |
@@ -57,7 +57,7 @@ jobs:
           run: dotnet test /src/tools/TestSuite/TestSuite.ApiTests/TestSuite.ApiTests.csproj --filter Category!=NotAutomated
 
       - name: Test - RUN on GooglePubSub
-        uses: kohlerdominik/docker-run-action@v1.1.0
+        uses: kohlerdominik/docker-run-action@v2.0.0
         with:
           image: mcr.microsoft.com/dotnet/sdk:8.0
           environment: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[kohlerdominik/docker-run-action](https://github.com/kohlerdominik/docker-run-action)** published a new release **[v2.0.0](https://github.com/kohlerdominik/docker-run-action/releases/tag/v2.0.0)** on 2024-02-27T16:41:17Z
