### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6.1.0
         with:
           load: true
           build-args: "NOTIFO__RUNTIME__VERSION=1.0.0-dev-${{ env.BUILD_NUMBER }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build - BUILD
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6.1.0
         with:
           load: true
           build-args: "NOTIFO__BUILD__VERSION=${{ env.GITHUB_REF_SLUG }},NOTIFO__RUNTIME__VERSION=${{ env.GITHUB_REF_SLUG }}"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.1.0](https://github.com/docker/build-push-action/releases/tag/v6.1.0)** on 2024-06-21T07:43:57Z
