### PR TITLE
Fix updating the user preferences

### DIFF
--- a/frontend/src/app/pages/users/UserDialog.tsx
+++ b/frontend/src/app/pages/users/UserDialog.tsx
@@ -133,7 +133,7 @@ export const UserDialog = (props: UserDialogProps) => {
                                             <hr />
 
                                             {allProperties.map(x =>
-                                                <Forms.Text key={x.name} name={x.name} hints={x.editorDescription}
+                                                <Forms.Text key={x.name} name={`properties.${x.name}`} hints={x.editorDescription}
                                                     label={x.editorLabel || x.name} />,
                                             )}
                                         </>


### PR DESCRIPTION
As mentioned in #38  , updating the user properties didn't work previously.

In the user upsert function,

https://github.com/notifo-io/notifo/blob/86cfa0861f03fa890c24dc1585ec720b779a0bb5/backend/src/Notifo.Domain/Users/UpsertUser.cs#L53

The properties are meant to be kept in the `Properties` field
https://github.com/notifo-io/notifo/blob/86cfa0861f03fa890c24dc1585ec720b779a0bb5/backend/src/Notifo.Domain/Users/UpsertUser.cs#L84-L90

While on the front-end side, the properties are sent directly at the "root" level of the DTO, e.g. here's an example POST request

```json
{
  "requests": [
    {
      "id": "c1729fd5-527d-497f-97c5-db31b69af57d",
      ...
      "properties": {}, // Empty object, should contain the properties
      "settings": {},
      "counters": {},
      "mobilePushTokens": [],
      "webPushSubscriptions": [],
      "userProperties": [
        {
          "name": "telegramChatId",
          "editorDescription": "The ID to identity the user in the chat with the bot. Will be set automatically.",
          "editorLabel": "Telegram Chat ID"
        },
        {
          "name": "telegramUserId",
          "editorDescription": "The username in telegram.",
          "editorLabel": "Telegram Username"
        }
      ],
        // Those properties shouldn't be here!
        "telegramChatId": "chat id", 
        "telegramUserId": "user id"
    }
  ]
}
```
That's because the form properties weren't registered inside "properties", but rather at the root level of the DTO.

On the other hand, the DTO on front-end is correct and assumes the properties are kept in the ```properties``` field

https://github.com/notifo-io/notifo/blob/86cfa0861f03fa890c24dc1585ec720b779a0bb5/frontend/src/app/service/service.ts#L6622-L6623

This pull request contains the fixes for this.