### PR TITLE
Introduce static field for the PropertyFormat to improve readability, add a test case

### DIFF
--- a/backend/src/Notifo.Domain.Integrations.Abstractions/IntegrationProperty.cs
+++ b/backend/src/Notifo.Domain.Integrations.Abstractions/IntegrationProperty.cs
@@ -5,11 +5,11 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
+using Notifo.Domain.Integrations.Resources;
+using Notifo.Infrastructure.Validation;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
-using Notifo.Domain.Integrations.Resources;
-using Notifo.Infrastructure.Validation;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 
@@ -17,6 +17,8 @@ namespace Notifo.Domain.Integrations;
 
 public sealed record IntegrationProperty(string Name, PropertyType Type)
 {
+    private static readonly string[] AllowedHttpUrlSchemes = { "http", "https" };
+
     public string? DefaultValue { get; init; }
 
     public string? EditorDescription { get; init; }
@@ -185,10 +187,7 @@ public sealed record IntegrationProperty(string Name, PropertyType Type)
 
                     break;
                 case PropertyFormat.HttpUrl:
-                    // We only allow "http" and "https" schemas to enable the usage of URL field for HttpClient requests.
-                    if (!Uri.TryCreate(input, UriKind.Absolute, out var uri)
-                        || (!string.Equals(uri.Scheme, "http", StringComparison.OrdinalIgnoreCase) && !string.Equals(uri.Scheme, "https", StringComparison.OrdinalIgnoreCase))
-                        )
+                    if (!Uri.TryCreate(input, UriKind.Absolute, out var uri) || !AllowedHttpUrlSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase))
                     {
                         error = Texts.IntegrationPropertyFormatHttpUrl;
                         return false;

--- a/backend/src/Notifo.Domain.Integrations.Abstractions/IntegrationProperty.cs
+++ b/backend/src/Notifo.Domain.Integrations.Abstractions/IntegrationProperty.cs
@@ -5,11 +5,11 @@
 //  All rights reserved. Licensed under the MIT license.
 // ==========================================================================
 
-using Notifo.Domain.Integrations.Resources;
-using Notifo.Infrastructure.Validation;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Notifo.Domain.Integrations.Resources;
+using Notifo.Infrastructure.Validation;
 
 #pragma warning disable SA1313 // Parameter names should begin with lower-case letter
 

--- a/backend/tests/Notifo.Domain.Tests/Integrations/IntegrationPropertyTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/IntegrationPropertyTests.cs
@@ -162,7 +162,7 @@ public class IntegrationPropertyTests
         [InlineData("localhost.com/test")]
         [InlineData("192.168.0.101")]
         [InlineData("randomString")]
-        public void Should_fail_if_url_is_invalid(string? input)
+        public void Should_fail_if_http_url_is_invalid(string? input)
         {
             var source = new Dictionary<string, string>
             {
@@ -182,7 +182,7 @@ public class IntegrationPropertyTests
         [InlineData("http://localhost/test")]
         [InlineData("https://example.com/test?query=example")]
         [InlineData("http://login:password@test.pl/random")]
-        public void Should_get_url_if_value_is_valid(string? input)
+        public void Should_get_http_url_if_value_is_valid(string? input)
         {
             var source = new Dictionary<string, string>
             {

--- a/backend/tests/Notifo.Domain.Tests/Integrations/IntegrationPropertyTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/IntegrationPropertyTests.cs
@@ -162,6 +162,7 @@ public class IntegrationPropertyTests
         [InlineData("localhost.com/test")]
         [InlineData("192.168.0.101")]
         [InlineData("randomString")]
+        [InlineData("mqtt://localhost:1883/")]
         public void Should_fail_if_http_url_is_invalid(string? input)
         {
             var source = new Dictionary<string, string>


### PR DESCRIPTION
Implements the suggestion you gave me in #248 

I also improved the naming of the PropertyFormat tests and added another HttpUrl test case.

Have a nice day :)