### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4.0.0
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.3.2
+        uses: rlespinasse/github-slug-action@v5.0.0
 
       - name: Prepare - Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4.0.0
 
       - name: Prepare - Inject short Variables
-        uses: rlespinasse/github-slug-action@v4.3.2
+        uses: rlespinasse/github-slug-action@v5.0.0
 
       - name: Prepare - Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[rlespinasse/github-slug-action](https://github.com/rlespinasse/github-slug-action)** published a new release **[v5.0.0](https://github.com/rlespinasse/github-slug-action/releases/tag/v5.0.0)** on 2024-11-05T23:18:37Z
