### PR TITLE
Fix FCM deprecated WebPush token

### DIFF
--- a/backend/src/Notifo.Domain/Channels/WebPush/WebPushChannel.cs
+++ b/backend/src/Notifo.Domain/Channels/WebPush/WebPushChannel.cs
@@ -155,7 +155,7 @@ public sealed class WebPushChannel : SchedulingChannelBase<WebPushJob, WebPushCh
             await webPushClient.SendNotificationAsync(pushSubscription, json, cancellationToken: ct);
             return DeliveryResult.Handled;
         }
-        catch (WebPushException ex) when (ex.StatusCode == HttpStatusCode.Gone)
+        catch (WebPushException ex) when (ex.StatusCode is HttpStatusCode.Gone or HttpStatusCode.NotFound)
         {
             // Use the same log message for the delivery result later.
             var logMessage = LogMessage.WebPush_TokenInvalid(Name, job.Notification.UserId, job.Subscription.Endpoint);


### PR DESCRIPTION
Google made a change for fcm tokens, trying to remove deprecated and stale tokens.
When trying to send notifications to this tokens, you get a response of 404 not found. Currently in notifo this code is not handled and only throws an exception. Results in sending again and again.
https://pushpad.xyz/blog/fcm-returns-404-for-stale-push-subscriptions