### PR TITLE
Add seven (seven.io) SMS provider integration

### DIFF
--- a/backend/src/Notifo.Domain.Integrations/Resources/Texts.Designer.cs
+++ b/backend/src/Notifo.Domain.Integrations/Resources/Texts.Designer.cs
@@ -574,6 +574,69 @@ namespace Notifo.Domain.Integrations.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to API Key.
+        /// </summary>
+        internal static string Seven_ApiKeyLabel {
+            get {
+                return ResourceManager.GetString("Seven_ApiKeyLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Send SMS via seven (seven.io) using your API Key..
+        /// </summary>
+        internal static string Seven_Description {
+            get {
+                return ResourceManager.GetString("Seven_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to send SMS to &apos;{0}&apos;: {1}.
+        /// </summary>
+        internal static string Seven_Error {
+            get {
+                return ResourceManager.GetString("Seven_Error", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to send SMS to &apos;{0}&apos;..
+        /// </summary>
+        internal static string Seven_ErrorUnknown {
+            get {
+                return ResourceManager.GetString("Seven_ErrorUnknown", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sender name or phone number shown as the sender of the SMS..
+        /// </summary>
+        internal static string Seven_FromDescription {
+            get {
+                return ResourceManager.GetString("Seven_FromDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to From.
+        /// </summary>
+        internal static string Seven_FromLabel {
+            get {
+                return ResourceManager.GetString("Seven_FromLabel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to seven SMS.
+        /// </summary>
+        internal static string Seven_Name {
+            get {
+                return ResourceManager.GetString("Seven_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Send emails using a custom email server..
         /// </summary>
         internal static string SMTP_Description {

--- a/backend/src/Notifo.Domain.Integrations/Resources/Texts.resx
+++ b/backend/src/Notifo.Domain.Integrations/Resources/Texts.resx
@@ -288,6 +288,27 @@
   <data name="MessageBird_WhatsAppTemplateNamespaceLabel" xml:space="preserve">
     <value>Template Namespace</value>
   </data>
+  <data name="Seven_ApiKeyLabel" xml:space="preserve">
+    <value>API Key</value>
+  </data>
+  <data name="Seven_Description" xml:space="preserve">
+    <value>Send SMS via seven (seven.io) using your API Key.</value>
+  </data>
+  <data name="Seven_Error" xml:space="preserve">
+    <value>Failed to send SMS to '{0}': {1}</value>
+  </data>
+  <data name="Seven_ErrorUnknown" xml:space="preserve">
+    <value>Failed to send SMS to '{0}'.</value>
+  </data>
+  <data name="Seven_FromDescription" xml:space="preserve">
+    <value>Sender name or phone number shown as the sender of the SMS.</value>
+  </data>
+  <data name="Seven_FromLabel" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="Seven_Name" xml:space="preserve">
+    <value>seven SMS</value>
+  </data>
   <data name="SMTP_Description" xml:space="preserve">
     <value>Send emails using a custom email server.</value>
   </data>

--- a/backend/src/Notifo.Domain.Integrations/Resources/Texts.tr.resx
+++ b/backend/src/Notifo.Domain.Integrations/Resources/Texts.tr.resx
@@ -270,6 +270,27 @@
   <data name="MessageBird_WhatsAppTemplateNamespaceLabel" xml:space="preserve">
     <value>Şablon Alanadı</value>
   </data>
+  <data name="Seven_ApiKeyLabel" xml:space="preserve">
+    <value>API Key</value>
+  </data>
+  <data name="Seven_Description" xml:space="preserve">
+    <value>seven (seven.io) kullanarak API Key ile SMS gönderin.</value>
+  </data>
+  <data name="Seven_Error" xml:space="preserve">
+    <value>'{0}' numarasına SMS gönderilemedi: {1}</value>
+  </data>
+  <data name="Seven_ErrorUnknown" xml:space="preserve">
+    <value>'{0}' numarasına SMS gönderilemedi.</value>
+  </data>
+  <data name="Seven_FromDescription" xml:space="preserve">
+    <value>SMS gönderici olarak görüntülenen gönderen adı veya telefon numarası.</value>
+  </data>
+  <data name="Seven_FromLabel" xml:space="preserve">
+    <value>Gönderen</value>
+  </data>
+  <data name="Seven_Name" xml:space="preserve">
+    <value>seven SMS</value>
+  </data>
   <data name="SMTP_Description" xml:space="preserve">
     <value>E-postaları özel bir e-posta sunucu kullanarak gönder.</value>
   </data>

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/ISevenSmsClient.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/ISevenSmsClient.cs
@@ -1,0 +1,14 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+namespace Notifo.Domain.Integrations.Seven.Implementation;
+
+public interface ISevenSmsClient
+{
+    Task<SevenSmsResponse> SendSmsAsync(string to, string text, string? from,
+        CancellationToken ct);
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsClient.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsClient.cs
@@ -1,0 +1,67 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Notifo.Infrastructure;
+
+namespace Notifo.Domain.Integrations.Seven.Implementation;
+
+public sealed class SevenSmsClient : ISevenSmsClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new ()
+    {
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
+    };
+
+    private readonly string apiKey;
+    private readonly IHttpClientFactory httpClientFactory;
+
+    public SevenSmsClient(string apiKey, IHttpClientFactory httpClientFactory)
+    {
+        this.apiKey = apiKey;
+        this.httpClientFactory = httpClientFactory;
+    }
+
+    public async Task<SevenSmsResponse> SendSmsAsync(string to, string text, string? from,
+        CancellationToken ct)
+    {
+        using var httpClient = httpClientFactory.CreateClient();
+
+        httpClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+        httpClient.DefaultRequestHeaders.Add("SentWith", "notifo");
+        httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        var request = new SevenSmsMessage
+        {
+            To = to,
+            Text = text,
+            From = from
+        };
+
+        var json = JsonSerializer.Serialize(request);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await httpClient.PostAsync("https://gateway.seven.io/api/sms", content, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
+
+            throw new HttpIntegrationException<object>(
+                $"Seven API request failed with status {(int)response.StatusCode}: {body}",
+                (int)response.StatusCode);
+        }
+
+        var result = await JsonSerializer.DeserializeAsync<SevenSmsResponse>(
+            await response.Content.ReadAsStreamAsync(ct), JsonOptions, ct);
+
+        return result ?? throw new HttpIntegrationException<object>("Failed to deserialize Seven API response.");
+    }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsClient.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsClient.cs
@@ -12,22 +12,13 @@ using Notifo.Infrastructure;
 
 namespace Notifo.Domain.Integrations.Seven.Implementation;
 
-public sealed class SevenSmsClient : ISevenSmsClient
+public sealed class SevenSmsClient(string apiKey, IHttpClientFactory httpClientFactory) : ISevenSmsClient
 {
     private static readonly JsonSerializerOptions JsonOptions = new ()
     {
         PropertyNameCaseInsensitive = true,
         NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
     };
-
-    private readonly string apiKey;
-    private readonly IHttpClientFactory httpClientFactory;
-
-    public SevenSmsClient(string apiKey, IHttpClientFactory httpClientFactory)
-    {
-        this.apiKey = apiKey;
-        this.httpClientFactory = httpClientFactory;
-    }
 
     public async Task<SevenSmsResponse> SendSmsAsync(string to, string text, string? from,
         CancellationToken ct)

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsMessage.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsMessage.cs
@@ -1,0 +1,23 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Text.Json.Serialization;
+
+namespace Notifo.Domain.Integrations.Seven.Implementation;
+
+public sealed class SevenSmsMessage
+{
+    [JsonPropertyName("to")]
+    public string To { get; set; }
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+
+    [JsonPropertyName("from")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? From { get; set; }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsResponse.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsResponse.cs
@@ -14,7 +14,7 @@ namespace Notifo.Domain.Integrations.Seven.Implementation;
 public sealed class SevenSmsResponse
 {
     [JsonPropertyName("success")]
-    public string Success { get; set; }
+    public string StatusCode { get; set; }
 
     [JsonPropertyName("total_price")]
     public decimal TotalPrice { get; set; }

--- a/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsResponse.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/Implementation/SevenSmsResponse.cs
@@ -1,0 +1,54 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Text.Json.Serialization;
+
+#pragma warning disable MA0048 // File name must match type name
+
+namespace Notifo.Domain.Integrations.Seven.Implementation;
+
+public sealed class SevenSmsResponse
+{
+    [JsonPropertyName("success")]
+    public string Success { get; set; }
+
+    [JsonPropertyName("total_price")]
+    public decimal TotalPrice { get; set; }
+
+    [JsonPropertyName("balance")]
+    public decimal Balance { get; set; }
+
+    [JsonPropertyName("sms_type")]
+    public string SmsType { get; set; }
+
+    [JsonPropertyName("messages")]
+    public SevenSmsResponseMessage[] Messages { get; set; }
+}
+
+public sealed class SevenSmsResponseMessage
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("sender")]
+    public string Sender { get; set; }
+
+    [JsonPropertyName("recipient")]
+    public string Recipient { get; set; }
+
+    [JsonPropertyName("text")]
+    public string Text { get; set; }
+
+    [JsonPropertyName("price")]
+    public decimal Price { get; set; }
+
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("encoding")]
+    public string Encoding { get; set; }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/SevenServiceExtensions.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/SevenServiceExtensions.cs
@@ -1,0 +1,25 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using Notifo.Domain.Integrations;
+using Notifo.Domain.Integrations.Seven;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+public static class SevenServiceExtensions
+{
+    public static IServiceCollection AddIntegrationSeven(this IServiceCollection services)
+    {
+        services.AddSingletonAs<SevenSmsIntegration>()
+            .As<IIntegration>();
+
+        services.AddSingletonAs<SevenSmsClientPool>()
+            .AsSelf();
+
+        return services;
+    }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsClientPool.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsClientPool.cs
@@ -1,0 +1,26 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using Microsoft.Extensions.Caching.Memory;
+using Notifo.Domain.Integrations.Seven.Implementation;
+
+namespace Notifo.Domain.Integrations.Seven;
+
+public sealed class SevenSmsClientPool(IMemoryCache memoryCache, IHttpClientFactory httpClientFactory) : CachePool<ISevenSmsClient>(memoryCache)
+{
+    public ISevenSmsClient GetClient(string apiKey)
+    {
+        var cacheKey = $"SevenSmsSender_{apiKey}";
+
+        var found = GetOrCreate(cacheKey, () =>
+        {
+            return new SevenSmsClient(apiKey, httpClientFactory);
+        });
+
+        return found;
+    }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.Sms.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.Sms.cs
@@ -25,10 +25,13 @@ public sealed partial class SevenSmsIntegration : ISmsSender
 
             var response = await client.SendSmsAsync(to, message.Text, from, ct);
 
-            var successCode = response.Success;
+            var statusCode = response.StatusCode;
 
             // 100 = SMS sent, 101 = SMS sent to multiple recipients
-            if (successCode != "100" && successCode != "101")
+            var isSuccess = (statusCode == "100" || statusCode == "101")
+                && response.Messages?.Any(m => !m.Success) != true;
+
+            if (!isSuccess)
             {
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, Texts.Seven_ErrorUnknown, to);
 

--- a/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.Sms.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.Sms.cs
@@ -1,0 +1,58 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using System.Globalization;
+using Notifo.Domain.Integrations.Resources;
+using Notifo.Infrastructure;
+
+namespace Notifo.Domain.Integrations.Seven;
+
+public sealed partial class SevenSmsIntegration : ISmsSender
+{
+    public async Task<DeliveryResult> SendAsync(IntegrationContext context, SmsMessage message,
+        CancellationToken ct)
+    {
+        var to = message.To;
+
+        try
+        {
+            var from = FromProperty.GetString(context.Properties);
+            var client = GetClient(context);
+
+            var response = await client.SendSmsAsync(to, message.Text, from, ct);
+
+            var successCode = response.Success;
+
+            // 100 = SMS sent, 101 = SMS sent to multiple recipients
+            if (successCode != "100" && successCode != "101")
+            {
+                var errorMessage = string.Format(CultureInfo.CurrentCulture, Texts.Seven_ErrorUnknown, to);
+
+                throw new DomainException(errorMessage);
+            }
+
+            return DeliveryResult.Sent;
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            var errorMessage = string.Format(CultureInfo.CurrentCulture, Texts.Seven_Error, to, ex.Message);
+
+            throw new DomainException(errorMessage);
+        }
+    }
+
+    private Implementation.ISevenSmsClient GetClient(IntegrationContext context)
+    {
+        var apiKey = ApiKeyProperty.GetString(context.Properties);
+
+        return clientPool.GetClient(apiKey);
+    }
+}

--- a/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.cs
+++ b/backend/src/Notifo.Domain.Integrations/Seven/SevenSmsIntegration.cs
@@ -1,0 +1,46 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using Notifo.Domain.Integrations.Resources;
+
+namespace Notifo.Domain.Integrations.Seven;
+
+public sealed partial class SevenSmsIntegration(SevenSmsClientPool clientPool) : IIntegration
+{
+    public static readonly IntegrationProperty ApiKeyProperty = new IntegrationProperty("apiKey", PropertyType.Password)
+    {
+        EditorLabel = Texts.Seven_ApiKeyLabel,
+        EditorDescription = null,
+        IsRequired = true
+    };
+
+    public static readonly IntegrationProperty FromProperty = new IntegrationProperty("from", PropertyType.Text)
+    {
+        EditorLabel = Texts.Seven_FromLabel,
+        EditorDescription = Texts.Seven_FromDescription,
+        IsRequired = false,
+        Summary = true
+    };
+
+    public IntegrationDefinition Definition { get; } =
+        new IntegrationDefinition(
+            "Seven",
+            Texts.Seven_Name,
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><rect width='200' height='200' rx='24' fill='#59C864'/><path d='M45 60h110l-65 105h-20l50-85H45z' fill='#fff'/></svg>",
+            [
+                ApiKeyProperty,
+                FromProperty
+            ],
+            [],
+            new HashSet<string>
+            {
+                Providers.Sms
+            })
+        {
+            Description = Texts.Seven_Description
+        };
+}

--- a/backend/src/Notifo/Startup.cs
+++ b/backend/src/Notifo/Startup.cs
@@ -145,6 +145,7 @@ public class Startup(IConfiguration config)
         services.AddIntegrationMailchimp();
         services.AddIntegrationMailjet();
         services.AddIntegrationMessageBird(config);
+        services.AddIntegrationSeven();
         services.AddIntegrationOpenNotifications(config);
         services.AddIntegrationSmtp();
         services.AddIntegrationTelegram();

--- a/backend/tests/Notifo.Domain.Tests/Integrations/Seven/SevenTests.cs
+++ b/backend/tests/Notifo.Domain.Tests/Integrations/Seven/SevenTests.cs
@@ -1,0 +1,37 @@
+// ==========================================================================
+//  Notifo.io
+// ==========================================================================
+//  Copyright (c) Sebastian Stehle
+//  All rights reserved. Licensed under the MIT license.
+// ==========================================================================
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Notifo.Domain.Integrations.Seven;
+
+[Trait("Category", "Dependencies")]
+public class SevenTests : SmsSenderTestBase
+{
+    protected override ResolvedIntegration<ISmsSender> CreateSender()
+    {
+        var apiKey = TestHelpers.Configuration.GetValue<string>("sms:seven:apiKey")!;
+        var from = TestHelpers.Configuration.GetValue<string>("sms:seven:from");
+
+        var context = BuildContext(new Dictionary<string, string>
+        {
+            [SevenSmsIntegration.ApiKeyProperty.Name] = apiKey,
+            [SevenSmsIntegration.FromProperty.Name] = from ?? string.Empty,
+        });
+
+        var integration =
+            new ServiceCollection()
+                .AddIntegrationSeven()
+                .AddMemoryCache()
+                .AddHttpClient()
+                .BuildServiceProvider()
+                .GetRequiredService<SevenSmsIntegration>();
+
+        return new ResolvedIntegration<ISmsSender>(Guid.NewGuid().ToString(), context, integration);
+    }
+}

--- a/backend/tests/Notifo.Domain.Tests/appsettings.json
+++ b/backend/tests/Notifo.Domain.Tests/appsettings.json
@@ -2,11 +2,6 @@
     "sms": {
         "to": "",
 
-        "seven": {
-            "apiKey": "",
-            "from": ""
-        },
-
         "messageBird": {
             "accessKey": "",
             "phoneNumber": "",

--- a/backend/tests/Notifo.Domain.Tests/appsettings.json
+++ b/backend/tests/Notifo.Domain.Tests/appsettings.json
@@ -2,6 +2,11 @@
     "sms": {
         "to": "",
 
+        "seven": {
+            "apiKey": "",
+            "from": ""
+        },
+
         "messageBird": {
             "accessKey": "",
             "phoneNumber": "",


### PR DESCRIPTION
## Summary

- Adds **seven** (seven.io) as a new SMS provider integration
- Follows the existing Notifo integration pattern (Integration, ISmsSender, ClientPool, DI registration)
- Sends SMS via the Seven REST API (`POST https://gateway.seven.io/api/sms`) with `X-Api-Key` authentication
- Configurable properties: API Key (required), sender name/number (optional)
- Includes localization entries and integration test

## New files

- `Seven/SevenSmsIntegration.cs` — Integration definition (type, logo, properties)
- `Seven/SevenSmsIntegration.Sms.cs` — ISmsSender implementation
- `Seven/SevenServiceExtensions.cs` — DI registration
- `Seven/SevenSmsClientPool.cs` — Client pool (CachePool pattern)
- `Seven/Implementation/ISevenSmsClient.cs` — Client interface
- `Seven/Implementation/SevenSmsClient.cs` — HTTP client
- `Seven/Implementation/SevenSmsMessage.cs` — Request model
- `Seven/Implementation/SevenSmsResponse.cs` — Response model
- `SevenTests.cs` — Integration test (SmsSenderTestBase)

## Modified files

- `Startup.cs` — Register `AddIntegrationSeven()`
- `Texts.resx` / `Texts.Designer.cs` / `Texts.tr.resx` — Localization entries
- `appsettings.json` — Test config placeholder for Seven

## Test plan

- [x] `dotnet build` passes (0 errors, 0 warnings)
- [x] Integration tests pass with valid Seven API key
- [ ] Manual test: Add seven SMS integration in Notifo dashboard, send test SMS